### PR TITLE
Fix attrnames unit test failure

### DIFF
--- a/tests/testthat/test-attribute_names.R
+++ b/tests/testthat/test-attribute_names.R
@@ -5,17 +5,21 @@ n <- 100
 
 test_that("attrnames finds the names of the attributes of a matrix", {
   x <- matrix(seq_len(n), ncol = p)
-  colnames(x) <- LETTERS[seq_len(p)]
+  colnames(x) <- letters[seq_len(p)]
   expect_true(
-    all(attrnames(x) %in% c("dim", "dimnames"))
+    setequal(
+      attrnames(x), c("dim", "dimnames")
+    )
   )
 })
 
 test_that("attrnames finds the names of the attributes of a data frame", {
   x <- matrix(seq_len(n), ncol = p)
-  colnames(x) <- LETTERS[seq_len(p)]
+  colnames(x) <- letters[seq_len(p)]
   y <- data.frame(x)
   expect_true(
-    all(attrnames(y) %in% c("names", "row.names", "class"))
+    setequal(
+      attrnames(y), c("names", "row.names", "class")
+    )
   )
 })


### PR DESCRIPTION
This PR attempts to fix a problem reported in #18, wherein `expect_identical` and similar tests of equivalence are too strong for the unit test of the `attrnames` function. The unit test is changed to use a combination of `setequal` and `expect_true` to circumvent this problem.